### PR TITLE
Bugfixing

### DIFF
--- a/spade/scraper/middlewares.py
+++ b/spade/scraper/middlewares.py
@@ -38,15 +38,20 @@ class CustomOffsiteMiddleware(OffsiteMiddleware):
                 yield req
 
     def should_follow(self, response, request):
-        """Follow if not offsite link, with exception of .css and .js files"""
+        """
+        We shouldn't follow a link if it goes offsite, with exception of .css
+        and .js files because a lot of people use CDNs and the like to host
+        their js and stylesheets.
+        """
         req_domain = urlparse(response.url)
         res_domain = urlparse(request.url)
 
-        # Allow CSS and JS files
         extension = res_domain.path.split(".")[-1]
         if extension in ['css', 'js']:
+            # Allow CSS and JS files
             return True
 
+        # Otherwise, ensure that the domains share the same root origin
         return req_domain.netloc == res_domain.netloc
 
     def spider_opened(self, spider):

--- a/spade/scraper/middlewares.py
+++ b/spade/scraper/middlewares.py
@@ -13,8 +13,6 @@ import spade.model.models as models
 import re
 import warnings
 
-
-
 # Define middleware here
 
 class CustomOffsiteMiddleware(OffsiteMiddleware):

--- a/spade/scraper/middlewares.py
+++ b/spade/scraper/middlewares.py
@@ -85,14 +85,11 @@ class CustomDepthMiddleware(object):
 
                 content_type = request.meta['content_type'] or []
 
-                mimes_to_ignore = ['text/css',
-                                   'text/javascript',
-                                   'script/javascript']
-
-                # Allow inclusion of the correct depth of js/css
-                for mime in mimes_to_ignore:
-                    if mime in content_type:
-                        depth = response.request.meta['depth']
+                # Allow inclusion of the correct depth of js/css or other
+                # linked file up to 1 level deeper (this works by undoing the
+                # depth counter by 1 for non-html files)
+                if 'text/html' not in content_type:
+                    depth = response.request.meta['depth']
 
                 # Check if we need to filter
                 if self.prio:

--- a/spade/scraper/middlewares.py
+++ b/spade/scraper/middlewares.py
@@ -41,16 +41,16 @@ class CustomOffsiteMiddleware(OffsiteMiddleware):
         and .js files because a lot of people use CDNs and the like to host
         their js and stylesheets.
         """
-        req_domain = urlparse(response.url)
-        res_domain = urlparse(request.url)
+        res_url_data = urlparse(response.url)
+        req_url_data = urlparse(request.url)
 
-        extension = res_domain.path.split(".")[-1]
+        extension = req_url_data.path.split(".")[-1]
         if extension in ['css', 'js']:
             # Allow CSS and JS files
             return True
 
         # Otherwise, ensure that the domains share the same root origin
-        return req_domain.netloc == res_domain.netloc
+        return req_url_data.netloc == res_url_data.netloc
 
     def spider_opened(self, spider):
         """Scrapy signal catching function: spider open"""

--- a/spade/scraper/pipelines.py
+++ b/spade/scraper/pipelines.py
@@ -26,7 +26,7 @@ class ScraperPipeline(object):
                     'application/javascript')
 
         # Parse each file based on what its MIME specifies
-        if 'text/html' in item['content_type']:
+        if 'text/html' == item['content_type']:
             # First save the request contents into a URLContent
             urlcontent = model.URLContent.objects.create(
                 url_scan=item['urlscan'], user_agent = item['user_agent'])
@@ -43,7 +43,7 @@ class ScraperPipeline(object):
 
             urlcontent.save()
 
-        elif any(mime in item['content_type'] for mime in js_mimes):
+        elif any(mime == item['content_type'] for mime in js_mimes):
             linkedjs = model.LinkedJS.objects.create(url_scan=item['urlscan'])
 
             # Store raw js
@@ -53,7 +53,7 @@ class ScraperPipeline(object):
 
             linkedjs.save()
 
-        elif 'text/css' in item['content_type']:
+        elif 'text/css' == item['content_type']:
             linkedcss = model.LinkedCSS.objects.create(
                 url_scan=item['urlscan'])
 

--- a/spade/scraper/settings.py
+++ b/spade/scraper/settings.py
@@ -29,8 +29,12 @@ DOWNLOADER_MIDDLEWARES = {
 
 # Disable the default filtering middleware and enable our own which only allows
 # following internal links of a site (no offsite hyperlinks allowed!)
+# Also disable depth middleware and replace with our own which only applies to
+# HTML (not CSS or Javascripts)
 SPIDER_MIDDLEWARES = {
     'scrapy.contrib.spidermiddleware.offsite.OffsiteMiddleware':None,
+    'scrapy.contrib.spidermiddleware.depth.DepthMiddleware':None,
+    'spade.scraper.middlewares.CustomDepthMiddleware': 542,
     'spade.scraper.middlewares.CustomOffsiteMiddleware': 543,
 }
 

--- a/spade/scraper/spiders/general_spider.py
+++ b/spade/scraper/spiders/general_spider.py
@@ -135,8 +135,10 @@ class GeneralSpider(BaseSpider):
                 except TypeError:
                     hyperlinks = []
 
+                # Using a set removes duplicate links.
+                all_links = set(hyperlinks + js_links + css_links)
+
                 # Examine links, yield requests if they are valid
-                all_links = hyperlinks + js_links + css_links
                 for url in all_links:
 
                     if not url.startswith('http://'):

--- a/spade/scraper/spiders/general_spider.py
+++ b/spade/scraper/spiders/general_spider.py
@@ -64,7 +64,11 @@ class GeneralSpider(BaseSpider):
         if headers:
             for h, val in headers.items():
                 if h.lower().strip() == 'content-type':
-                    return val
+                    # As it turns out, content-type often appears with some
+                    # additional values e.g "text/css; charset=utf8" so we want
+                    # to turn that into a list, allowing us to access just
+                    # 'text/css' rather than the whole string
+                    return val[0].split(";")
 
         return ""
 
@@ -105,6 +109,7 @@ class GeneralSpider(BaseSpider):
                 new_request.meta['referrer'] = None
                 new_request.meta['sitescan'] = sitescan
                 new_request.meta['user_agent'] = ua
+                new_request.meta['content_type'] = content_type
                 new_request.dont_filter = True
 
                 yield new_request
@@ -145,6 +150,7 @@ class GeneralSpider(BaseSpider):
                     request.meta['referrer'] = response.url
                     request.meta['sitescan'] = sitescan
                     request.meta['user_agent'] = None
+                    request.meta['content_type'] = None
                     request.dont_filter = True
 
                     yield request

--- a/spade/scraper/spiders/general_spider.py
+++ b/spade/scraper/spiders/general_spider.py
@@ -68,7 +68,7 @@ class GeneralSpider(BaseSpider):
                     # additional values e.g "text/css; charset=utf8" so we want
                     # to turn that into a list, allowing us to access just
                     # 'text/css' rather than the whole string
-                    return val[0].split(";")
+                    return val[0].split(";")[0]
 
         return ""
 
@@ -115,7 +115,7 @@ class GeneralSpider(BaseSpider):
                 yield new_request
 
             # Continue crawling
-            if 'text/html' in content_type:
+            if 'text/html' == content_type:
                 # Parse stylesheet links, scripts, and hyperlinks
                 hxs = HtmlXPathSelector(response)
 


### PR DESCRIPTION
- Fixed bug where sites containing two links to the same page emit two identical requests (thus saving duplicates)
- Replaced the default scrapy depth middleware with a modified one that allows JS and CSS to be saved 1 level deeper, so a page scanned at depth 2 might have a stylesheet on depth 3 but that will be saved with this modification.
- Modified the offsite middleware to allow remote JS and CSS because many sites use CDNs.
