### PR TITLE
Fix all the errors because of shady redirects; Mark sites with no URLScans (mail.ru - like) as 'bad'.

### DIFF
--- a/spade/model/models.py
+++ b/spade/model/models.py
@@ -172,7 +172,6 @@ class URLScan(models.Model):
 
     site_scan = models.ForeignKey(SiteScan, db_index=True)
     page_url = models.TextField()
-    redirected_from = models.TextField()
     timestamp = models.DateTimeField("timestamp")
 
     # See comment for site_url_hash -- same reason.
@@ -195,6 +194,7 @@ class URLContent(models.Model):
     """
     url_scan = models.ForeignKey(URLScan)
     user_agent = models.ForeignKey(BatchUserAgent)
+    redirected_from = models.TextField()
     raw_markup = models.FileField(
         max_length=500, upload_to=html_filename)
     headers = models.FileField(

--- a/spade/scraper/items.py
+++ b/spade/scraper/items.py
@@ -17,3 +17,4 @@ class MarkupItem(Item):
     urlscan = Field()
     url = Field()
     user_agent = Field()
+    redirected_from = Field()

--- a/spade/scraper/middlewares.py
+++ b/spade/scraper/middlewares.py
@@ -29,11 +29,11 @@ class OffsiteMiddleware(offsite.OffsiteMiddleware):
 
 
     def should_follow(self, response, request):
-        """Only follow offsite links to JS files, not new pages."""
+        """Only follow offsite links to JS and CSS files, not new pages."""
         res_url_data = urlparse_cached(response)
         req_url_data = urlparse_cached(request)
 
-        if has_extension(request, 'js'):
+        if has_extension(request, 'js') or has_extension(request, 'css'):
             return True
 
         # Otherwise, ensure that the domains share the same root origin

--- a/spade/scraper/pipelines.py
+++ b/spade/scraper/pipelines.py
@@ -31,7 +31,9 @@ class ScraperPipeline(object):
         if 'text/html' == item['content_type']:
             # First save the request contents into a URLContent
             urlcontent = model.URLContent.objects.create(
-                url_scan=item['urlscan'], user_agent=item['user_agent'])
+                url_scan=item['urlscan'],
+                user_agent=item['user_agent'],
+                redirected_from=item['redirected_from'])
 
             # Store raw markup
             file_content = ContentFile(item['raw_content'])

--- a/spade/scraper/spiders/general_spider.py
+++ b/spade/scraper/spiders/general_spider.py
@@ -115,7 +115,6 @@ class GeneralSpider(BaseSpider):
 
                     site_scan=sitescan,
                     page_url_hash=sha256(response.url).hexdigest(),
-                    redirected_from=response.meta.get('redirected_from', u''),
                     defaults={'page_url': response.url,
                               'timestamp': self.get_now_time()})
 
@@ -175,5 +174,6 @@ class GeneralSpider(BaseSpider):
             item['urlscan'] = urlscan
             item['url'] = response.url
             item['user_agent'] = response.meta.get('user_agent')
-
+            item['redirected_from'] = response.meta.get('redirected_from',
+                                                        u'')
             yield item

--- a/spade/utils/data_aggregator.py
+++ b/spade/utils/data_aggregator.py
@@ -120,9 +120,14 @@ class DataAggregator(object):
         the data model and return it
         """
         # find all the invalid sitescans and delete them
+        # first, take out those with invalid domains
         requested_domains = [get_domain(s) for s in batch.sites]
         for sitescan in batch.sitescan_set.iterator():
             if not get_domain(sitescan.site_url) in requested_domains:
+                sitescan.delete()
+        # then take out those with no URLScans (a la mail.ru)
+        for sitescan in batch.sitescan_set.iterator():
+            if not sitescan.urlscan_set.count():
                 sitescan.delete()
 
         sitescans = model.SiteScan.objects.filter(batch=batch).iterator()

--- a/spade/utils/data_aggregator.py
+++ b/spade/utils/data_aggregator.py
@@ -357,12 +357,15 @@ class DataAggregator(object):
         # if we have less urlcontents than UAs, check for redirects,
         # like m.yahoo.com from yahoo.com
         if nr < sitescan.batch.batchuseragent_set.count():
-            redirs = sitescan.urlscan_set.filter(redirected_from=
-                                                 sitescan.site_url)
-            if redirs.count():
-                for mobile_homepage in redirs:
-                    for content in mobile_homepage.urlcontent_set.iterator():
-                        urlcontents.append(content)
+            # look in all urlscans
+            for urlscan in sitescan.urlscan_set.iterator():
+                # for urlcontents of pages redirected from the homepage
+                redirs = urlscan.urlcontent_set.filter(redirected_from=
+                                                       sitescan.site_url)
+                if not redirs.count():
+                    continue
+                for mobile_homepage_content in redirs:
+                        urlcontents.append(mobile_homepage_content)
         # update the number of urlcontents we need to check
         nr = len(urlcontents)
 

--- a/spade/utils/data_aggregator.py
+++ b/spade/utils/data_aggregator.py
@@ -196,7 +196,7 @@ class DataAggregator(object):
         # figure out the number of distinct css property issues
         css_issues = 0
         for prop_data in sitescan.csspropertydata_set.iterator():
-            if prop_data.moz_count < prop_data.webkit_count:
+            if not prop_data.supports_moz:
                 css_issues += 1
 
         # figure out if the website does UA sniffing or not

--- a/spade/view/templates/site_css_report.html
+++ b/spade/view/templates/site_css_report.html
@@ -24,7 +24,7 @@
                 <th>no prefix</th>
             </tr>
             {% for prop, counts in props_data %}
-                {% if counts.0 < counts.1 %}
+                {% if counts.0 < counts.1 and counts.2 < counts.1 %}
                     <tr class="bad">
                 {% else %}
                     <tr class="good">


### PR DESCRIPTION
UA part seems fine now.

I think we need to get back to allowing off-site CSS because it seems we aren't really downloading too much of it now that we disabled that functionality. I guess most sites keep their CSS off the main domain?
