### PR TITLE
fix vagrant setup

### DIFF
--- a/puppet/manifests/classes/spade.pp
+++ b/puppet/manifests/classes/spade.pp
@@ -13,7 +13,7 @@ class spade{
     }
 
     exec { "grant_mysql_database":
-        command => "mysql -uroot -B -e'GRANT ALL PRIVILEGES ON $DB_NAME.* TO $DB_USER@localhost # IDENTIFIED BY \"$DB_PASS\"'",
+        command => "mysql -uroot -B -e'GRANT ALL PRIVILEGES ON *.* TO $DB_USER@localhost IDENTIFIED BY \"$DB_PASS\"'",
         unless  => "mysql -uroot -B --skip-column-names mysql -e 'select user from user' | grep '$DB_USER'",
         require => Exec["create_mysql_database"];
     }
@@ -22,15 +22,5 @@ class spade{
         cwd => "$PROJ_DIR",
         command => "/home/vagrant/spade-venv/bin/python ./manage.py syncdb --noinput",
         require => Exec["grant_mysql_database"];
-    }
-
-    exec { "sql_migrate":
-        cwd => "$PROJ_DIR",
-        command => "python ./vendor/src/schematic/schematic migrations/",
-        require => [
-            Service["mysql"],
-            Package["python2.6-dev", "libapache2-mod-wsgi", "python-wsgi-intercept" ],
-            Exec["syncdb"]
-        ];
     }
 }

--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -7,12 +7,30 @@ $PROJ_DIR = "/home/vagrant/project"
 
 # You can make these less generic if you like, but these are box-specific
 # so it's not required.
+
 $DB_NAME = "spade"
-$DB_USER = "root"
+$DB_USER = "spade_user"
+$DB_PASS = "spade_pass"
+$DB_HOST = "localhost"
+$DB_PORT = "3306"
+$DJANGO_SECRET_KEY = "5up3r53cr3t"
 
 Exec {
     path => "/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
 }
+
+file {"/etc/profile.d/spade.sh":
+    content => "
+export SPADE_DATABASE_NAME='${DB_NAME}'
+export SPADE_DATABASE_USER='${DB_USER}'
+export SPADE_DATABASE_PASSWORD='${DB_PASS}'
+export SPADE_DATABASE_HOST='${DB_HOST}'
+export SPADE_DATABASE_PORT='${DB_PORT}'
+export SPADE_DEBUG='1'
+export SPADE_DJANGO_SECRET_KEY='${DJANGO_SECRET_KEY}'
+"
+}
+
 
 class dev {
     class {

--- a/spade/settings/base.py
+++ b/spade/settings/base.py
@@ -2,12 +2,12 @@
 Default Django Settings for Spade
 
 """
+import os
 from os.path import dirname, join, abspath
-from os import environ
 
 
 BASE_PATH = dirname(dirname(dirname(abspath(__file__))))
-environ['SCRAPY_SETTINGS_MODULE'] = 'spade.scraper.settings'
+os.environ['SCRAPY_SETTINGS_MODULE'] = 'spade.scraper.settings'
 
 CSS_PROPS_FILE = join(BASE_PATH, 'spade', 'utils', 'css_property_list.txt')
 
@@ -15,24 +15,24 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 ADMINS = [
-    ("Sam Liu", "sliu@mozilla.com"),
-    ("Carl Meyer", "cmeyer@mozilla.com"),
 ]
 
 MANAGERS = ADMINS
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'spade',                       # Or path to database file if using sqlite3.
-        'USER': '',                            # Not used with sqlite3.
-        'PASSWORD': '',                        # Not used with sqlite3.
-        'HOST': '',                            # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                            # Set to empty string for default. Not used with sqlite3.
+    "default": {
+        "ENGINE"   : "django.db.backends.mysql",
+        "NAME"     : os.environ.get("SPADE_DATABASE_NAME", ""),
+        "USER"     : os.environ.get("SPADE_DATABASE_USER", ""),
+        "PASSWORD" : os.environ.get("SPADE_DATABASE_PASSWORD", ""),
+        "HOST"     : os.environ.get("SPADE_DATABASE_HOST", "localhost"),
+        "PORT"     : os.environ.get("SPADE_DATABASE_PORT", ""),
         'OPTIONS': {
-            'init_command': 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED; SET storage_engine=InnoDB;'},
+            "init_command": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED; SET storage_engine=InnoDB;"
+        },
     }
 }
+
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/spade/settings/local.sample.py
+++ b/spade/settings/local.sample.py
@@ -6,15 +6,19 @@ adjustment for a staging or production deployment.
 Copy local.sample.py to local.py and modify as needed.
 """
 # Local settings (overrides)
+import os
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'myuser_spade',               # Or path to database file if using sqlite3.
-        'USER': 'myuser',                     # Not used with sqlite3.
-        'PASSWORD': 'mypass',                 # Not used with sqlite3.
-        'HOST': '',                           # Set to empty string for localhost. Not used with sqlite3.
-        'PORT': '',                           # Set to empty string for default. Not used with sqlite3.
+    "default": {
+        "ENGINE"   : "django.db.backends.mysql",
+        "NAME"     : os.environ.get("SPADE_DATABASE_NAME", ""),
+        "USER"     : os.environ.get("SPADE_DATABASE_USER", ""),
+        "PASSWORD" : os.environ.get("SPADE_DATABASE_PASSWORD", ""),
+        "HOST"     : os.environ.get("SPADE_DATABASE_HOST", "localhost"),
+        "PORT"     : os.environ.get("SPADE_DATABASE_PORT", ""),
+        'OPTIONS': {
+            "init_command": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED; SET storage_engine=InnoDB;"
+        },
     }
 }
 


### PR DESCRIPTION
I removed the references to schematic from the puppet manifest. I also put the db credentials in a bunch of environment variables. The default settings file will inspect those variables, so the information is not repeated in different places.
